### PR TITLE
[TASK] Adds GPS data into exif and splits keywords in IPTC

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -47,7 +47,6 @@ class ImageMetadataExtractor extends AbstractExtractor {
 	protected $iptcAttributesMapping = array(
 		'2#005' => 'title',
 		'2#120' => 'caption',
-		// TODO: do we need to split() the value of this field?
 		'2#025' => 'keywords',
 		'2#115' => 'publisher',
 		'2#080' => 'creator',
@@ -155,6 +154,10 @@ class ImageMetadataExtractor extends AbstractExtractor {
 			$exif = $data['EXIF'];
 			if (is_array($data['IFD0'])) {
 				$exif = array_merge($data['IFD0'], $exif);
+			}
+			// adds GPS data from global exif data
+			if (is_array($data['GPS']) && !isset($exif['GPS'])) {
+				$exif['GPS'] = $data['GPS'];
 			}
 
 			$this->processExifData($metadata, $exif);
@@ -313,7 +316,12 @@ class ImageMetadataExtractor extends AbstractExtractor {
 			if (is_array($iptc)) {
 				foreach ($this->iptcAttributesMapping as $attribute => $mediaField) {
 					if (isset($iptc[$attribute])) {
-						$metadata[$mediaField] = $iptc[$attribute][0];
+						// store categories as comma separated values in DB
+						if ($mediaField === 'keywords') {
+							$metadata[$mediaField] = implode(',', $iptc[$attribute]);
+						} else {
+							$metadata[$mediaField] = $iptc[$attribute][0];
+						}
 					}
 				}
 			}

--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -366,7 +366,14 @@ class ImageMetadataExtractor extends AbstractExtractor {
 	 */
 	protected function parseGpsCoordinate($value, $ref) {
 		if (is_array($value)) {
-			$neutralValue = $value[0] + ((($value[1] * 60) + ($value[2])) / 3600);
+			$processedValue = array();
+			foreach ($value as $key => $item) {
+				if (strpos($item, '/') !== FALSE) {
+					$parts = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode('/', $item);
+					$processedValue[$key] = (int) ($parts[0] / $parts[1]);
+				}
+			}
+			$neutralValue = $processedValue[0] + ((($processedValue[1] * 60) + ($processedValue[2])) / 3600);
 			$value = ($ref === 'N' || $ref === 'E') ? $neutralValue : '-' . $neutralValue;
 		}
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -25,7 +25,7 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' =>
     array (
       'cms' => '',
-      'typo3' => '6.2.0-6.2.99',
+      'typo3' => '6.2.0-7.99.99',
     ),
     'conflicts' =>
     array (


### PR DESCRIPTION
- Adds GPS data from global exif data to extract it
- Implodes an array of keywords to store it as CSV into DB
- Runs nice on 7.3.1, so updated the ext_emconf file
- Processes GPS data if more exact coordinates given
