### PR TITLE
Display content_date in sys_file_metadata TCA

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -208,6 +208,7 @@ if (version_compare(TYPO3_version, '7.1', '<')) {
 				--palette--;;30;;,
 				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.metrics;50;;,
 				--palette--;;51;;,
+				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.content_date;60,
 			--div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,categories'
 		),
 	);
@@ -229,6 +230,7 @@ if (version_compare(TYPO3_version, '7.1', '<')) {
 				--palette--;;30;;,
 				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.metrics;50;;,
 				--palette--;;51;;,
+				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.content_date;60,
 			--div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,categories'
 		),
 	);


### PR DESCRIPTION
Display content_creation_date and content_modification_date of images, audio files and videos in the TCA of sys_file_metadata records.

https://forge.typo3.org/issues/76267
