### PR TITLE
Add renderType for select fields

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -100,6 +100,7 @@ $tca = array(
 			'label' => 'LLL:EXT:metadata/Resources/Private/Language/locallang.xlf:sys_file_metadata.flash',
 			'config' => array(
 				'type' => 'select',
+				'renderType' => 'selectSingle',
 				'default' => '-1',
 				'items' => array(
 					array('', '0'),
@@ -136,6 +137,7 @@ $tca = array(
 			'config' => array(
 				'type' => 'select',
 				'default' => '-1',
+				'renderType' => 'selectSingle',
 				'itemListStyle' => 'width:200px;',
 				'items' => array(
 					array('', '0'),


### PR DESCRIPTION
Defining the 'renderType' => 'selectSingle' for the select fields avoids entries in the deprecation log of TYPO3 7.6 like
`Using select fields without the "renderType" setting is deprecated in table "sys_file_metadata" and column "flash"`
`Using select fields without the "renderType" setting is deprecated in table "sys_file_metadata" and column "metering_mode"`