### PR TITLE
Add only defined colorSpaces

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -436,8 +436,10 @@ class ImageMetadataExtractor extends AbstractExtractor {
 	protected function getColorSpace($value) {
 		if (array_key_exists($value, $this->colorSpaceToNameMapping)) {
 			$value = $this->colorSpaceToNameMapping[$value];
+		} else {
+			$value = ''
 		}
 
-		return (string)$value;
+		return $value;
 	}
 }


### PR DESCRIPTION
Avoid an SQL exception for the color_space value `65535` by allowing only those colorSpaces defined in colorSpaceToNameMapping