### PR TITLE
[BUGFIX] No SQL error for images w/o GPS coordinates

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -396,7 +396,7 @@ class ImageMetadataExtractor extends AbstractExtractor {
 	 * @param array $value
 	 * @param string $ref
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	protected function parseGpsCoordinate($value, $ref) {
 		if (is_array($value)) {
@@ -415,7 +415,7 @@ class ImageMetadataExtractor extends AbstractExtractor {
 			$value = ($ref === 'N' || $ref === 'E') ? $neutralValue : '-' . $neutralValue;
 		}
 
-		return (string)$value;
+		return $value === null ? null : (string)$value;
 	}
 
 	/**


### PR DESCRIPTION
Avoid a SQL exception on PostgreSQL for images w/o GPS coordinates by setting `null` instead of an empty string `''`

Closes: https://github.com/fabarea/metadata/issues/27