### PR TITLE
Change field credit to match db field and iptc

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -20,8 +20,8 @@ $tca = array(
 			'label' => 'LLL:EXT:metadata/Resources/Private/Language/locallang.xlf:sys_file_metadata.credit',
 			'config' => array(
 				'type' => 'input',
-				'size' => 40,
-				'max' => '255',
+				'size' => 30,
+				'max' => '32',
 				'eval' => 'trim'
 			),
 		),


### PR DESCRIPTION
File metadata field credit should match the allowed length of field in db and from the iptc specification
See https://www.iptc.org/std/IIM/4.1/specification/IIMV4.1.pdf
#32 