### PR TITLE
Handle IFD0 data if there is no EXIF subarray

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -171,9 +171,16 @@ class ImageMetadataExtractor extends AbstractExtractor {
 			$data = @exif_read_data($filename, 0, TRUE);
 		}
 
+		$ifd0merged = false; // do not merge two times
+		// if the EXIF read data is empty but the IFD0 exists, merge the IFD0 data to the data EXIF subarray
+		if (!is_array($data['EXIF']) && is_array($data['IFD0']) ) {
+		    $data['EXIF'] = array_merge($data['IFD0'], []);
+		    $ifd0merged = true;
+		}
+
 		if (is_array($data['EXIF'])) {
 			$exif = $data['EXIF'];
-			if (is_array($data['IFD0'])) {
+			if (is_array($data['IFD0']) && !$ifd0merged) {
 				$exif = array_merge($data['IFD0'], $exif);
 			}
 			// adds GPS data from global exif data

--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -171,18 +171,13 @@ class ImageMetadataExtractor extends AbstractExtractor {
 			$data = @exif_read_data($filename, 0, TRUE);
 		}
 
-		$ifd0merged = false; // do not merge two times
 		// if the EXIF read data is empty but the IFD0 exists, merge the IFD0 data to the data EXIF subarray
-		if (!is_array($data['EXIF']) && is_array($data['IFD0']) ) {
-		    $data['EXIF'] = array_merge($data['IFD0'], []);
-		    $ifd0merged = true;
+		if (is_array($data['IFD0']) ) {
+		    $data['EXIF'] = array_merge($data['IFD0'], ( is_array($data['EXIF'] ) ) ? $data['EXIF'] : [] );
 		}
 
 		if (is_array($data['EXIF'])) {
 			$exif = $data['EXIF'];
-			if (is_array($data['IFD0']) && !$ifd0merged) {
-				$exif = array_merge($data['IFD0'], $exif);
-			}
 			// adds GPS data from global exif data
 			if (is_array($data['GPS']) && !isset($exif['GPS'])) {
 				$exif['GPS'] = $data['GPS'];


### PR DESCRIPTION
Handle IFD0 data (if exists) even if the `$data['EXIF']` data is empty after exif_read_data().

I was confused that sometimes the meta data is there automatically and sometimes not. 
With xdebug, it turns out that sometimes the `$data['EXIF']` is unserialized, but the meta data is there in `$data['IFD0']`.
It seems that this depends on the program that is used to create the image.

If I merge that before handling the `$data['EXIF']` array, everything is fine.  
