### PR TITLE
[BUGFIX] Do not overwrite EXIF content_creation_date with IPTC

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -344,6 +344,10 @@ class ImageMetadataExtractor extends AbstractExtractor {
 						// store categories as comma separated values in DB
 						if ($mediaField === 'keywords') {
 							$metadata[$mediaField] = implode(',', $iptc[$attribute]);
+						} elseif ($mediaField === 'content_creation_date') {
+							if (empty($metadata[$mediaField])) {
+								$metadata[$mediaField] = strtotime($iptc[$attribute][0]);
+							}
 						} else {
 							$metadata[$mediaField] = $iptc[$attribute][0];
 						}


### PR DESCRIPTION
Only set IPTC content_creation_date if its not set by EXIF as
IPTC only contains a date and EXIF contains date and time.

Also parse the IPTC creation date with `strtotime()` in order
to receive the necessary UNIX timestamp.

Fixes https://github.com/fabarea/metadata/issues/41