### PR TITLE
[TASK] Clean up ext_localconf.php

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,36 +1,30 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-    die ('Access denied.');
-}
-
-$extractMetadataImage = $extractMetadataPdf = true;
+defined('TYPO3_MODE') || die('Access denied.');
 
 // Get extension configuration
 if (class_exists(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)) {
-    $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-        \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
-    );
-    $configuration = $extensionConfiguration->get('metadata');
+	$extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+		\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+	);
+	$configuration = $extensionConfiguration->get('metadata');
 } else {
-    // @extensionScannerIgnoreLine Fallback to access extConf for TYPO3 CMS version below 9.5
-    if (isset($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metadata'])
-        && !empty($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metadata'])
-    ) {
-        $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metadata'];
-        if (!is_array($configuration)) {
-            $configuration = unserialize($configuration);
-        }
-    }
+	// @extensionScannerIgnoreLine Fallback to access extConf for TYPO3 CMS version below 9.5
+	if (!empty($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metadata'])) {
+		$configuration = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['metadata'];
+		if (!is_array($configuration)) {
+			$configuration = unserialize($configuration);
+		}
+	}
 }
 
 // Register metadata extractor for images if configured so.
-if (isset($configuration['extract_image_metadata']) && (bool)$configuration['extract_image_metadata']) {
-    \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
-        ->registerExtractionService('Fab\Metadata\Index\ImageMetadataExtractor');
+if (!empty($configuration['extract_image_metadata'])) {
+	\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
+		->registerExtractionService(\Fab\Metadata\Index\ImageMetadataExtractor::class);
 }
 
 // Register metadata extractor for pdf if configured so.
-if (isset($configuration['extract_pdf_metadata']) && (bool)$configuration['extract_pdf_metadata']) {
-    \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
-        ->registerExtractionService('Fab\Metadata\Index\PdfMetadataExtractor');
+if (!empty($configuration['extract_pdf_metadata'])) {
+	\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()
+		->registerExtractionService(\Fab\Metadata\Index\PdfMetadataExtractor::class);
 }


### PR DESCRIPTION
- PHP7 syntax
- Refer to classes using ::class syntax
- Consistent indents using \t
- isset() is not required before empty()