### PR TITLE
[BUGFIX] Save copyright to existing column and fix missing columns

### DIFF
--- a/Classes/Index/ImageMetadataExtractor.php
+++ b/Classes/Index/ImageMetadataExtractor.php
@@ -60,7 +60,7 @@ class ImageMetadataExtractor extends AbstractExtractor {
 		'2#115' => 'source',
 		'2#080' => 'creator',
 		'2#110' => 'credit',
-		'2#116' => 'copyright_notice',
+		'2#116' => 'copyright',
 		'2#100' => 'location_country',
 		'2#090' => 'location_city',
 		'2#055' => 'content_creation_date',
@@ -243,7 +243,7 @@ class ImageMetadataExtractor extends AbstractExtractor {
 				case 'Copyright':
 				case 'CopyrightNotice':
 				case 'Rights':
-					$metadata['copyright_notice'] = $value;
+					$metadata['copyright'] = $value;
 					break;
 
 				case 'Credit':

--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -3,15 +3,11 @@ defined('TYPO3_MODE') || die('Access denied.');
 
 $tca = [
 	'palettes' => [
-		'20' => ['showitem' => 'publisher, source', 'canNotCollapse' => '1'],
-		'21' => ['showitem' => 'creator_tool, copyright_notice', 'canNotCollapse' => '1'],
 		'22' => [
-			'showitem' => 'iso_speed_ratings, aperture_value, shutter_speed_value, focal_length',
+			'showitem' => 'iso_speed_ratings, aperture_value, shutter_speed_value, focal_length, --linebreak--, camera_model, flash, metering_mode',
 			'canNotCollapse' => '1'
 		],
-		'23' => ['showitem' => 'camera_model, flash, metering_mode', 'canNotCollapse' => '1'],
 		'51' => ['showitem' => 'horizontal_resolution, vertical_resolution', 'canNotCollapse' => '1'],
-		'61' => ['showitem' => 'credit', 'canNotCollapse' => '1'],
 	],
 	'columns' => [
 		'credit' => [
@@ -22,17 +18,6 @@ $tca = [
 				'type' => 'input',
 				'size' => 30,
 				'max' => '32',
-				'eval' => 'trim'
-			],
-		],
-		'copyright_notice' => [
-			'exclude' => 1,
-			'l10n_display' => 'defaultAsReadonly',
-			'label' => 'LLL:EXT:metadata/Resources/Private/Language/locallang.xlf:sys_file_metadata.copyright_notice',
-			'config' => [
-				'type' => 'input',
-				'size' => 40,
-				'max' => '255',
 				'eval' => 'trim'
 			],
 		],
@@ -200,28 +185,26 @@ $tca = [
 				],
 			]
 		],
-	],
-	'types' => [
-		TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE => ['showitem' => '
-			fileinfo, title, description, alternative, keywords, caption, download_name,
-			--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
-				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.visibility;10;;,
-				fe_groups,
-			--div--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:tabs.metadata,
-				creator,
-				--palette--;;20;;,
-				--palette--;;21;;,
-				--palette--;;61;;,
-				--palette--;LLL:EXT:metadata/Resources/Private/Language/locallang.xlf:palette.exif;22;;,
-				--palette--;;23;;,
-				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.geo_location;40;;,
-				--palette--;;30;;,
-				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.metrics;50;;,
-				--palette--;;51;;,
-				--palette--;LLL:EXT:filemetadata/Resources/Private/Language/locallang_tca.xlf:palette.content_date;60,
-			--div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,categories'
-		],
 	]
 ];
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+	'sys_file_metadata',
+	'credit',
+	TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE,
+	'after:copyright'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+	'sys_file_metadata',
+	'--palette--;LLL:EXT:metadata/Resources/Private/Language/locallang.xlf:palette.exif;22;;',
+	TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE,
+	'after:color_space'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+	'sys_file_metadata',
+	'--palette--;;51',
+	TYPO3\CMS\Core\Resource\File::FILETYPE_IMAGE,
+	'after:unit'
+);
 
 \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA']['sys_file_metadata'], $tca);

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -10,10 +10,6 @@
 				<source>Credit</source>
 				<target>Anbieter</target>
 			</trans-unit>
-			<trans-unit id="sys_file_metadata.copyright_notice">
-				<source>Copyright notice</source>
-				<target>Urheberrechts-Hinweis</target>
-			</trans-unit>
 			<trans-unit id="sys_file_metadata.aperture_value">
 				<source>Aperture Value (F)</source>
 				<target>Blendenzahl (F)</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -9,9 +9,6 @@
 			<trans-unit id="sys_file_metadata.credit">
 				<source>Credit</source>
 			</trans-unit>
-			<trans-unit id="sys_file_metadata.copyright_notice">
-				<source>Copyright notice</source>
-			</trans-unit>
 			<trans-unit id="sys_file_metadata.aperture_value">
 				<source>Aperture Value (F)</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,7 +3,6 @@
 #
 CREATE TABLE sys_file_metadata (
 	credit varchar(32) DEFAULT '' NOT NULL,
-	copyright_notice varchar(255) DEFAULT '' NOT NULL,
 	aperture_value float unsigned DEFAULT '0' NOT NULL,
 	shutter_speed_value varchar(24) DEFAULT '' NOT NULL,
 	iso_speed_ratings varchar(24) DEFAULT '' NOT NULL,


### PR DESCRIPTION
- Save copyright to the existing `copyright` column (since TYPO3 8.7) instead of adding a new `copyright_notice` column
- Rework adding of additional EXIF columns by adding them after existing columns using `ExtensionManagementUtility::addToAllTCAtypes()` instead of replacing the full type definition of `File::FILETYPE_IMAGE` - this makes the missing columns (e.g. `ranking`, `categories`) reappear and keeps the TCA structure as defined by the core

Fixes https://github.com/fabarea/metadata/issues/3
Fixes https://github.com/fabarea/metadata/issues/17